### PR TITLE
Update Bonus Calculation Method to Use Min-Max Scaling

### DIFF
--- a/1-Introduction/04-stats-and-probability/notebook.ipynb
+++ b/1-Introduction/04-stats-and-probability/notebook.ipynb
@@ -830,7 +830,7 @@
    "source": [
     "## Correlation and Evil Baseball Corp\n",
     "\n",
-    "Correlation allows us to find relations between data sequences. In our toy example, let's pretend there is an evil baseball corporation that pays its players according to their height - the taller the player is, the more money he/she gets. Suppose there is a base salary of $1000, and an additional bonus from $0 to $100, depending on height. We will take the real players from MLB, and compute their imaginary salaries:"
+    "Correlation allows us to find relations between data sequences. In our toy example, let's pretend there is an evil baseball corporation that pays its players according to their height - the taller the player is, the more money he/she gets. Suppose there is a base salary of $1000, and an additional bonus from $0 to $100, depending on height. We will take the real players from MLB, and compute their imaginary salaries(based on Min-Max scaling):"
    ]
   },
   {
@@ -848,7 +848,7 @@
    ],
    "source": [
     "heights = df['Height']\n",
-    "salaries = 1000+(heights-heights.min())/(heights.max()-heights.mean())*100\n",
+    "salaries = 1000+(heights-heights.min())/(heights.max()-heights.min())*100\n",
     "print(list(zip(heights, salaries))[:10])"
    ]
   },
@@ -935,7 +935,7 @@
     }
    ],
    "source": [
-    "salaries = 1000+np.sin((heights-heights.min())/(heights.max()-heights.mean()))*100\n",
+    "salaries = 1000+np.sin((heights-heights.min())/(heights.max()-heights.min()))*100\n",
     "print(f\"Correlation = {np.corrcoef(heights, salaries)[0,1]}\")"
    ]
   },
@@ -960,7 +960,7 @@
     }
    ],
    "source": [
-    "salaries = 1000+np.sin((heights-heights.min())/(heights.max()-heights.mean()))*100+np.random.random(size=len(heights))*20-10\n",
+    "salaries = 1000+np.sin((heights-heights.min())/(heights.max()-heights.min()))*100+np.random.random(size=len(heights))*20-10\n",
     "print(f\"Correlation = {np.corrcoef(heights, salaries)[0,1]}\")"
    ]
   },


### PR DESCRIPTION
According to the context, if we calculate the bonus with the base height.max() - height.mean(), then the bonus might exceed 100. To address this issue and ensure that the bonus remains within a reasonable range, I propose using Min-Max scaling. This will help normalize the bonus calculation and prevent it from becoming excessively large.