### PR TITLE
[Folder 1 - Lesson 4 notebook] Missing Data

### DIFF
--- a/1-Introduction/04-stats-and-probability/notebook.ipynb
+++ b/1-Introduction/04-stats-and-probability/notebook.ipynb
@@ -487,7 +487,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.corrcoef(df['Height'],df['Weight'])"
+    "np.corrcoef(df['Height'].ffill(),df['Weight'])"
    ]
   },
   {


### PR DESCRIPTION
Add .ffill() and .fillna() because there are missing values in the height column (at row 641). In particular the diagrams for the boxplot and the correlation matrix will not load because some of the height values are missing at row 641. To fix this, I used .ffill() and .fillna() to make up for the missing values. On one line, used for calculating coeff, the .fillna() should be on the height column instead of the weight column because height has missing values, not weight. 