### PR TITLE
chore: bump braces to 3.0.3 in starter lockfile

### DIFF
--- a/3-Data-Visualization/13-meaningful-visualizations/starter/package-lock.json
+++ b/3-Data-Visualization/13-meaningful-visualizations/starter/package-lock.json
@@ -9011,10 +9011,10 @@
 				"node": ">=8.6"
 			}
 		},
-		"node_modules/micromatch/node_modules/braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"node_modules/micromatch/node_modules/braces": {
+				"version": "3.0.3",
+				"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+				"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
 			"dependencies": {
 				"fill-range": "^7.0.1"
@@ -12661,10 +12661,10 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/webpack-dev-server/node_modules/braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"node_modules/webpack-dev-server/node_modules/braces": {
+				"version": "3.0.3",
+				"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+				"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
 			"dependencies": {
 				"fill-range": "^7.0.1"


### PR DESCRIPTION
## Summary\n- update transitive `braces` entries in the starter lockfile from `3.0.2` to `3.0.3`\n- update tarball URL and integrity hash to the official `3.0.3` values\n\n## Validation\n- confirmed no `braces-3.0.2.tgz` entries remain in the updated lockfile\n\nFixes #751