### PR TITLE
fix: correct malformed URL missing slash in lesson 14

### DIFF
--- a/4-Data-Science-Lifecycle/14-Introduction/README.md
+++ b/4-Data-Science-Lifecycle/14-Introduction/README.md
@@ -91,7 +91,7 @@ Explore the [Team Data Science Process lifecycle](https://docs.microsoft.com/en-
 |Team Data Science Process (TDSP)|Cross-industry standard process for data mining (CRISP-DM)|
 |--|--|
 |![Team Data Science Lifecycle](./images/tdsp-lifecycle2.png) | ![Data Science Process Alliance Image](./images/CRISP-DM.png) |
-| Image by [Microsoft](https://docs.microsoft.comazure/architecture/data-science-process/lifecycle) | Image by [Data Science Process Alliance](https://www.datascience-pm.com/crisp-dm-2/) |
+| Image by [Microsoft](https://docs.microsoft.com/azure/architecture/data-science-process/lifecycle) | Image by [Data Science Process Alliance](https://www.datascience-pm.com/crisp-dm-2/) |
 
 ## [Post-lecture quiz](https://ff-quizzes.netlify.app/en/ds/quiz/27)
 


### PR DESCRIPTION
## Summary
Fixes a malformed URL in `4-Data-Science-Lifecycle/14-Introduction/README.md`.

The link `https://docs.microsoft.comazure/architecture/data-science-process/lifecycle` was missing a `/` between `docs.microsoft.com` and `azure`, making it an invalid URL.

## Testing
- Verified the corrected URL resolves to the Azure Data Science lifecycle documentation