### PR TITLE
Fixed typo in README.md

### DIFF
--- a/2-Working-With-Data/07-python/README.md
+++ b/2-Working-With-Data/07-python/README.md
@@ -122,7 +122,7 @@ This will give us a table like this:
 
 **Note** that we can also get this table layout by transposing the previous table, eg. by writing 
 ```python
-df = pd.DataFrame([a,b]).T..rename(columns={ 0 : 'A', 1 : 'B' })
+df = pd.DataFrame([a,b]).T.rename(columns={ 0 : 'A', 1 : 'B' })
 ```
 Here `.T` means the operation of transposing the DataFrame, i.e. changing rows and columns, and `rename` operation allows us to rename columns to match the previous example.
 


### PR DESCRIPTION
### Description
Fixed a syntax typo in the Python README code snippet where a double dot (`..`) was accidentally used instead of a single dot (`.`) for method chaining.

### Changes
* **File:** `2-Working-With-Data/07-python/README.md` (Line 125)
* **Before:** `df = pd.DataFrame([a,b]).T..rename(columns={ 0 : 'A', 1 : 'B' })`
* **After:** `df = pd.DataFrame([a,b]).T.rename(columns={ 0 : 'A', 1 : 'B' })`

This fix ensures the code block is syntactically correct and runs without errors if copied by users.