### PR TITLE
Fix typo in notebook-covidspread

### DIFF
--- a/2-Working-With-Data/07-python/notebook-covidspread.ipynb
+++ b/2-Working-With-Data/07-python/notebook-covidspread.ipynb
@@ -1793,7 +1793,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now let's compute the number of new infected people each day. This will allow us to see the speed at which pandemic progresses. The easiest day to do it is to use `diff`:"
+    "Now let's compute the number of new infected people each day. This will allow us to see the speed at which pandemic progresses. The easiest way to do it is to use `diff`:"
    ]
   },
   {


### PR DESCRIPTION
### Description

This pull request fixes a small typo in the `2-Working-With-Data/07-python/notebook-covidspread.ipynb` notebook.

**Before: -** "The easiest **d**ay to do it is to use `diff`:"
**After: -**"The easiest **w**ay to do it is to use `diff`:"

### Type of Change

* ✅ Documentation / typo fix

### Notes

This change only corrects the wording in the explanatory Markdown text and does not affect any code or notebook functionality.
