### PR TITLE
[Lesson 3] Fix broken link in defining-data readme

### DIFF
--- a/1-Introduction/03-defining-data/README.md
+++ b/1-Introduction/03-defining-data/README.md
@@ -65,7 +65,7 @@ Kaggle is an excellent source of open datasets. Use the [dataset search tool](ht
 
 ## Review & Self Study
 
-- This Microsoft Learn unit, titled [Classify your Data](https://docs.microsoft.com/en-us/learn/modules/choose-storage-approach-in-azure/2-classify-data) has a detailed breakdown of structured, semi-structured, and unstructured data.
+- This Microsoft Learn unit, titled [Identify data formats](https://learn.microsoft.com/en-us/training/modules/explore-core-data-concepts/2-data-formats?pivots=text) has a detailed breakdown of structured, semi-structured, and unstructured data.
 
 ## Assignment
 


### PR DESCRIPTION
**What**: Updates a broken/incorrect link in
1-Introduction/03-defining-data/readme.md.

**Why**: The link pointed to the Azure Blob Storage overview page
instead of content relevant to classifying data types, which is
what the surrounding text describes.

**How**: Replaced the old link with the correct Microsoft Learn
module, "Identify data formats," which correctly covers data
classification as intended by the original text.

**Testing**: Manually verified the new link resolves correctly
and matches the content described in the readme.