### PR TITLE
[Lesson 4] Fix deprecated matplotlib and pandas API usage in notebook

### DIFF
--- a/1-Introduction/04-stats-and-probability/notebook.ipynb
+++ b/1-Introduction/04-stats-and-probability/notebook.ipynb
@@ -136,7 +136,7 @@
    "outputs": [],
    "source": [
     "plt.figure(figsize=(10,2))\n",
-    "plt.boxplot(df['Height'].ffill(), vert=False, showmeans=True)\n",
+    "plt.boxplot(df['Height'].ffill(), orientation='horizontal', showmeans=True)\n",
     "plt.grid(color='gray', linestyle='dotted')\n",
     "plt.tight_layout()\n",
     "plt.show()"
@@ -272,7 +272,7 @@
     "    return m, h\n",
     "\n",
     "for p in [0.85, 0.9, 0.95]:\n",
-    "    m, h = mean_confidence_interval(df['Weight'].fillna(method='pad'),p)\n",
+    "    m, h = mean_confidence_interval(df['Weight'].ffill(),p)\n",
     "    print(f\"p={p:.2f}, mean = {m:.2f} ± {h:.2f}\")"
    ]
   },
@@ -384,7 +384,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "heights = df['Height'].fillna(method='pad')\n",
+    "heights = df['Height'].ffill()\n",
     "salaries = 1000+(heights-heights.min())/(heights.max()-heights.mean())*100\n",
     "print(list(zip(heights, salaries))[:10])"
    ]
@@ -507,7 +507,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.corrcoef(df['Height'].fillna(method='pad'), df['Weight'])"
+    "np.corrcoef(df['Height'].ffill(), df['Weight'])"
    ]
   },
   {


### PR DESCRIPTION
**What**: Updates deprecated API calls in 1-Introduction/04-stats-and-probability/notebook.ipynb.

**Why**: Running the notebook with current pandas/matplotlib versions
throws errors due to removed or deprecated parameters:
- The boxplot cell under "Analyzing real data" used `vert=False`,
  deprecated in favor of `orientation='horizontal'`.
- One cell under "Confidence Intervals" and two cells under "Correlation and Evil Baseball Corp" used
  `.fillna(method='pad')`, which newer pandas versions removed in
  favor of the equivalent `.ffill()`.

**How**: Replaced `vert=False` with `orientation='horizontal'`, and
replaced `.fillna(method='pad')` with `.ffill()` in the affected cells.

**Testing**: Ran all affected cells locally with current pandas and
matplotlib versions; confirmed no errors and output matches expected
behavior.