### PR TITLE
docs: Fix grammar in multi-language support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Azure Cloud Advocates at Microsoft are pleased to offer a 10-week, 20-lesson cur
 > This gives you everything you need to complete the course with a much faster download.
 <!-- CO-OP TRANSLATOR LANGUAGES TABLE END -->
 
-**If you wish to have additional translations languages supported are listed [here](https://github.com/Azure/co-op-translator/blob/main/getting_started/supported-languages.md)**
+**If you wish to have additional translations, supported languages are listed [here](https://github.com/Azure/co-op-translator/blob/main/getting_started/supported-languages.md)**
 
 #### Join Our Community 
 [![Microsoft Foundry Discord](https://dcbadge.limes.pink/api/server/nTYy5BXMWG)](https://discord.gg/nTYy5BXMWG)


### PR DESCRIPTION
## Summary
This PR fixes a grammatical error in the multi-language support section for improved readability.

## What changed
- Changed 'translations languages supported' to 'translations, supported languages'
- Line 66 of README.md

## Why this matters
Minor grammar improvements maintain professional documentation standards and improve readability for the thousands of learners using this curriculum.

## Testing
- [x] Verified markdown renders correctly
- [x] Grammar is now correct
- [x] No functional changes

Simple fix but important for maintaining quality documentation.