### PR TITLE
[Lesson 7] Correct inverted Rt equation

### DIFF
--- a/2-Working-With-Data/07-python/notebook-covidspread.ipynb
+++ b/2-Working-With-Data/07-python/notebook-covidspread.ipynb
@@ -2266,7 +2266,7 @@
     "\n",
     "To see how infectious is the disease, we look at the **basic reproduction number** $R_0$, which indicated the number of people that an infected person would further infect. When $R_0$ is more than 1, the epidemic is likely to spread.\n",
     "\n",
-    "$R_0$ is a property of the disease itself, and does not take into account some protective measures that people may take to slow down the pandemic. During the pandemic progression, we can estimate the reproduction number $R_t$ at any given time $t$. It has been shown that this number can be roughly estimated by taking a window of 8 days, and computing $$R_t=\\frac{I_{t-7}+I_{t-6}+I_{t-5}+I_{t-4}}{I_{t-3}+I_{t-2}+I_{t-1}+I_t}$$\n",
+    "$R_0$ is a property of the disease itself, and does not take into account some protective measures that people may take to slow down the pandemic. During the pandemic progression, we can estimate the reproduction number $R_t$ at any given time $t$. It has been shown that this number can be roughly estimated by taking a window of 8 days, and computing $$R_t=\\frac{I_{t-3}+I_{t-2}+I_{t-1}+I_t}{I_{t-7}+I_{t-6}+I_{t-5}+I_{t-4}}$$\n",
     "where $I_t$ is the number of newly infected individuals on day $t$.\n",
     "\n",
     "Let's compute $R_t$ for our pandemic data. To do this, we will take a rolling window of 8 `ninfected` values, and apply the function to compute the ratio above:"


### PR DESCRIPTION
## What

Correct the displayed approximation for $R_t$ in the Lesson 7 COVID spread notebook by swapping the numerator and denominator.

## Why

The Markdown equation previously divided the earlier four-day infection total by the most recent four-day total. That direction contradicts the surrounding explanation: increasing infections would produce a value below 1.

## How

The corrected equation now divides the most recent four-day total by the preceding four-day total. This matches the existing notebook implementation:

```python
x[4:].sum() / x[:4].sum()
```

## Testing

- Parsed the notebook successfully with `jq empty`.
- Ran `git diff --check` successfully.
- Confirmed the change is limited to the single Markdown equation.

Closes #814.
